### PR TITLE
chore: support TYPO3 v13; drop support for v11 and below

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea/

--- a/Classes/Middleware/LanguageRedirectionMiddleware.php
+++ b/Classes/Middleware/LanguageRedirectionMiddleware.php
@@ -47,7 +47,7 @@ class LanguageRedirectionMiddleware implements MiddlewareInterface
         // Check which of the browser languages are supported by comparing two letter ISO codes
         foreach ($browserLanguageIsoCodes as $browserLanguageIsoCode) {
             foreach ($siteLanguages as $siteLanguage) {
-                if ($browserLanguageIsoCode === $siteLanguage->getTwoLetterIsoCode()) {
+                if ($browserLanguageIsoCode === $siteLanguage->getLocale()->getLanguageCode()) {
                     // Do nothing, if the site language base URL is the currently requested URL
                     if ((string) $siteLanguage->getBase() === $request->getAttribute('normalizedParams')->getRequestUrl()) {
                         return $handler->handle($request);

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         }
     ],
     "require": {
-        "typo3/cms-core": "9.5 - 12.4",
-        "php": "^7.2 || ^8.1"
+        "typo3/cms-core": "12.4 - 13.4",
+        "php": "^8.1"
     },
     "autoload": {
         "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -9,10 +9,10 @@ $EM_CONF[$_EXTKEY] = [
     'author_company' => 'visuellverstehen GmbH',
     'state' => 'stable',
     'clearCacheOnLoad' => false,
-    'version' => '1.0.0',
+    'version' => '2.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '9.5-12.4',
+            'typo3' => '12.4-13.4',
         ],
     ],
 ];


### PR DESCRIPTION
Because the usage of `$sitelanguage->getTwoLetterIsoCode()` [is deprecated since TYPO3 v12](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.3/Deprecation-99905-SiteLanguageIso-639-1Setting.html) and is therefore dropped in TYPO3 v13, we need to change to using `$siteLanguage->getLocale()->getLanguageCode()`.

With this change we need to drop support for all TYPO3 versions below v12, because the function did not exist before.